### PR TITLE
Add linting configuration and development documentation

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,75 @@
+version: 2
+
+linters:
+  disable-all: true
+  enable:
+    - errcheck # Check for unchecked errors in function calls
+    - govet # Official Go static analysis tool to find bugs and potential issues
+    - ineffassign # Detect unused assignments
+    - staticcheck # Advanced Go linter that detects bugs and performance issues
+    - unused # Check for unused constants, variables, functions and types
+    - asasalint # Detect pass of []any as any in variadic func(...any)
+    - asciicheck # Ensure identifiers only contain ASCII characters
+    - bidichk # Detect dangerous unicode character sequences
+    - bodyclose # Check whether HTTP response body is closed successfully
+    - contextcheck # Check whether the function uses a non-inherited context
+    - decorder # Verify consistency in declaration order (constants, variables, types)
+    - dogsled # Detect excessive use of blank identifiers in assignments
+    - errname # Enforce consistent error variable naming conventions
+    - errorlint # Find code that will cause problems with the error wrapping scheme
+    - copyloopvar # Check for pointers to enclosing loop variables
+    - gocheckcompilerdirectives # Verify compiler directives like //go:generate
+    - gochecknoinits # Check that no init functions are present in Go code
+    - goconst # Find repeated strings that could be replaced by a constant
+    - gocritic # Comprehensive Go source code linter
+    - godot # Check if comments end in a period
+    - goheader # Check presence and format of copyright headers
+    - gomodguard # Control package imports
+    - goprintffuncname # Enforce consistent printf-like function naming conventions
+    - grouper # Group related constant/variable/import/type declarations
+    - importas # Enforce consistent import aliases
+    - interfacebloat # Detect interface declarations with too many methods
+    - loggercheck # Check key value pairs for common logger libraries
+    - makezero # Find slice declarations with non-zero initial length
+    - misspell # Find commonly misspelled English words in comments
+    - nakedret # Find naked returns in functions larger than specified size
+    - nestif # Report deeply nested if statements
+    - nilerr # Find code returning nil when err is not nil
+    - noctx # Find HTTP requests sent without context.Context
+    - nolintlint # Report ill-formed or insufficient nolint directives
+    - prealloc # Find slice declarations that could potentially be pre-allocated
+    - predeclared # Find shadowing of Go's predeclared identifiers
+    - reassign # Check that package variables are not reassigned
+    - testableexamples # Check if examples are testable (have an expected output)
+    - testpackage # Make sure that separate _test packages are used
+    - tparallel # Detect inappropriate usage of t.Parallel() method in tests
+    - unconvert # Remove unnecessary type conversions
+    - unparam # Report unused function parameters
+    - usestdlibvars # Detect the possibility to use variables/constants from stdlib
+    - wastedassign # Find wasted assignment statements
+    - whitespace # Detect leading and trailing whitespace
+
+linters-settings:
+  errcheck:
+  govet:
+  staticcheck:
+    checks: ["all"]
+  unused:
+    check-exported: false
+  unparam:
+    check-exported: false
+  gocritic:
+  prealloc:
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+run:
+  timeout: 5m
+
+output:
+  format: colored-line-number
+  print-issued-lines: true
+  print-linter-name: true
+  uniq-by-line: true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean test install
+.PHONY: build clean test install lint lint-fix
 
 build:
 	go build -o gh-cp ./cmd/gh-cp
@@ -9,7 +9,13 @@ clean:
 test:
 	go test ./...
 
+lint:
+	golangci-lint run
+
+lint-fix:
+	golangci-lint run --fix
+
 install: build
-	cp gh-cp $(GOPATH)/bin/
+	cp gh-cp $(shell go env GOPATH)/bin/
 
 .DEFAULT_GOAL := build

--- a/README.md
+++ b/README.md
@@ -8,6 +8,36 @@ A CLI utility written in Go that allows you to cherry-pick entire GitHub pull re
 - GitHub CLI (`gh`) - must be pre-configured and authenticated
 - Git repository with proper access permissions
 
+## Installation
+
+### Quick Install (Recommended)
+
+```bash
+go install github.com/theyoprst/gh-cp/cmd/gh-cp@latest
+```
+
+This will download, build, and install the `gh-cp` binary to your `$(go env GOPATH)/bin` directory.
+
+### Alternative: Build from Source
+
+```bash
+# Clone the repository
+git clone https://github.com/theyoprst/gh-cp.git
+cd gh-cp
+
+# Build and install
+make install
+```
+
+### Verify Installation
+
+```bash
+# Check if gh-cp is available
+gh-cp --help
+```
+
+**Note**: Make sure your `$(go env GOPATH)/bin` is in your system's `$PATH` environment variable.
+
 ## Usage
 
 ```bash
@@ -78,3 +108,46 @@ In dry-run mode, the tool will:
 - 🔍 Show push command that would be executed
 - 🔍 Show PR creation command that would be executed
 - ✅ Clean up local branch and return to original state
+
+## Development
+
+### Building from Source
+
+```bash
+# Build the binary
+make build
+
+# Clean build artifacts
+make clean
+```
+
+### Code Quality
+
+```bash
+# Run linters
+make lint
+
+# Auto-fix linting issues where possible
+make lint-fix
+```
+
+### Testing
+
+```bash
+# Run tests
+make test
+```
+
+### Installation
+
+```bash
+# Build and install to $(go env GOPATH)/bin
+make install
+```
+
+### Project Structure
+
+- `cmd/gh-cp/` - Main application entry point
+- `internal/github/` - GitHub API integration
+- `internal/git/` - Git operations
+- `internal/cherry/` - Core cherry-pick logic

--- a/internal/cherry/picker.go
+++ b/internal/cherry/picker.go
@@ -1,3 +1,4 @@
+// Package cherry provides the main cherry-pick orchestration logic.
 package cherry
 
 import (
@@ -7,6 +8,7 @@ import (
 	"github.com/theyoprst/gh-cp/internal/github"
 )
 
+// CherryPickPR orchestrates the complete cherry-pick workflow for a GitHub PR.
 func CherryPickPR(prNumber int, targetBranch string, config *github.Config) error {
 	if !git.IsGitRepo() {
 		return fmt.Errorf("not in a git repository")

--- a/internal/cherry/pr_creator.go
+++ b/internal/cherry/pr_creator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/theyoprst/gh-cp/internal/github"
 )
 
+// CreatePR creates a new GitHub pull request with the cherry-picked changes.
 func CreatePR(prData *github.PRData, targetBranch string, dryRun bool) (prURL string, err error) {
 	title := fmt.Sprintf("[cherry-pick] %s", prData.Title)
 
@@ -24,14 +25,8 @@ func CreatePR(prData *github.PRData, targetBranch string, dryRun bool) (prURL st
 	}
 
 	if dryRun {
-		escapedTitle := strings.ReplaceAll(title, `"`, `\"`)
-		escapedBody := strings.ReplaceAll(body, `"`, `\"`)
-
-		fmt.Printf("[DRY RUN] Would execute: gh pr create --title \"%s\" --body \"%s\" --base \"%s\"", escapedTitle, escapedBody, targetBranch)
-		if len(labels) > 0 {
-			fmt.Printf(" --label \"%s\"", strings.Join(labels, ","))
-		}
-		fmt.Println()
+		cmdStr := fmt.Sprintf("gh %s", strings.Join(args, " "))
+		fmt.Printf("[DRY RUN] Would execute: %s\n", cmdStr)
 		return "", nil
 	}
 

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -1,3 +1,4 @@
+// Package git provides git operations for the cherry-pick utility.
 package git
 
 import (
@@ -5,12 +6,13 @@ import (
 	"strings"
 )
 
+// GenerateCherryPickBranchName creates a descriptive branch name for cherry-pick operations.
 func GenerateCherryPickBranchName(originalBranchName, targetBranch string, prNumber int) string {
 	if originalBranchName != "" {
 		cleanOriginal := strings.ReplaceAll(originalBranchName, "/", "-")
 		cleanTarget := strings.ReplaceAll(targetBranch, "/", "-")
 		return fmt.Sprintf("cherry-pick-to/%s/from/%s", cleanTarget, cleanOriginal)
 	}
-	
+
 	return fmt.Sprintf("cherry-pick-pr-%d", prNumber)
 }

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -1,3 +1,4 @@
+// Package github provides GitHub API integration via the gh CLI.
 package github
 
 import (


### PR DESCRIPTION
## Summary
- Add comprehensive golangci-lint configuration with 45+ linters
- Add Development section to README with build, lint, and test instructions
- Add Installation section with go install command for users
- Fix Makefile to use proper GOPATH reference

## Test plan
- Run make lint to verify linting configuration works
- Verify README installation instructions are clear and accurate