### PR TITLE
Implement git worktree support and fix branch conflicts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,52 @@ make install
 ./gh-cp <pr-number> <target-branch>
 ```
 
+## Testing
+
+### Test Data
+For development and testing, use these reference values:
+- **Test PR**: #10 "Add CLAUDE.md developer guide"
+- **Target branch**: `before-claude-md`
+
+### Dry-run Testing
+```bash
+# Basic dry-run test
+./gh-cp 10 before-claude-md --dry-run
+
+# Expected output:
+# ✓ Generated unique branch name: cherry-pick-to/before-claude-md/from/main/0
+# ✓ Created worktree at: /tmp/gh-cp-worktree-<random>
+# ✓ Cherry-picked 1 commits successfully
+# [DRY RUN] Would execute: git push --force -u origin ...
+# [DRY RUN] Would execute: gh pr create ...
+# ✓ Cleaning up worktree...
+# ✓ Cleaning up branch: cherry-pick-to/before-claude-md/from/main/0
+```
+
+### Branch Naming Verification
+Multiple runs should create incremental suffixes:
+```bash
+# First run (if no conflicts)
+./gh-cp 10 before-claude-md --dry-run
+# → cherry-pick-to/before-claude-md/from/main/0
+
+# Second run (increments suffix)
+./gh-cp 10 before-claude-md --dry-run
+# → cherry-pick-to/before-claude-md/from/main/1
+```
+
+### Cleanup Verification
+After each run, verify complete cleanup:
+```bash
+# Check no cherry-pick branches remain
+git branch | grep cherry-pick
+# Should return nothing
+
+# Check no temporary worktrees remain
+ls /tmp | grep gh-cp-worktree
+# Should return nothing
+```
+
 ## Architecture
 
 ### Package Structure
@@ -74,3 +120,7 @@ make install
 - **External**: GitHub CLI (`gh`) must be installed and authenticated
 - **Runtime**: Must be run from within a git repository
 - **Go modules**: Pure Go with no external dependencies in go.mod
+
+## Go Style Guide
+- When adding context to returned errors, keep the context succinct by avoiding phrases like "failed to", which state the obvious and pile up as the error percolates up through the stack
+- Do not add obvious comments in the code

--- a/cleanup_and_test.sh
+++ b/cleanup_and_test.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-cd /Users/viacheslavezhkin/projects/gh-cp-2
-git checkout initial
-git branch -D cherry-pick/add-readme-documentation 2>/dev/null || true
-exec /Users/viacheslavezhkin/projects/gh-cp/gh-cp 1 initial --dry-run

--- a/cleanup_and_test_real.sh
+++ b/cleanup_and_test_real.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-cd /Users/viacheslavezhkin/projects/gh-cp-2
-git checkout initial
-git branch -D cherry-pick/add-readme-documentation 2>/dev/null || true
-exec /Users/viacheslavezhkin/projects/gh-cp/gh-cp 1 initial

--- a/internal/cherry/pr_creator.go
+++ b/internal/cherry/pr_creator.go
@@ -9,7 +9,7 @@ import (
 )
 
 // CreatePR creates a new GitHub pull request with the cherry-picked changes.
-func CreatePR(prData *github.PRData, targetBranch string, dryRun bool) (prURL string, err error) {
+func CreatePR(prData *github.PRData, targetBranch, branchName string, dryRun bool) (prURL string, err error) {
 	title := fmt.Sprintf("[cherry-pick] %s", prData.Title)
 
 	body := fmt.Sprintf(`Cherry-picked from #%d
@@ -18,7 +18,7 @@ func CreatePR(prData *github.PRData, targetBranch string, dryRun bool) (prURL st
 
 	labels := github.FormatLabels(prData.Labels)
 
-	args := []string{"pr", "create", "--title", title, "--body", body, "--base", targetBranch}
+	args := []string{"pr", "create", "--title", title, "--body", body, "--base", targetBranch, "--head", branchName}
 
 	if len(labels) > 0 {
 		args = append(args, "--label", strings.Join(labels, ","))

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -1,0 +1,67 @@
+package git
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func CreateWorktree(branchName, targetBranch string) (string, error) {
+	worktreePath, err := GetUniqueWorktreePath()
+	if err != nil {
+		return "", err
+	}
+	
+	cmd := exec.Command("git", "worktree", "add", worktreePath, targetBranch)
+	if err := cmd.Run(); err != nil {
+		// Clean up the created directory if worktree creation fails
+		if removeErr := os.RemoveAll(worktreePath); removeErr != nil {
+			return "", fmt.Errorf("create worktree: %w (cleanup failed: %w)", err, removeErr)
+		}
+		return "", fmt.Errorf("create worktree: %w", err)
+	}
+	
+	return worktreePath, nil
+}
+
+func RemoveWorktree(worktreePath string) error {
+	cmd := exec.Command("git", "worktree", "remove", worktreePath)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("remove worktree: %w", err)
+	}
+	return nil
+}
+
+func GetUniqueWorktreePath() (string, error) {
+	worktreePath, err := os.MkdirTemp("", "gh-cp-worktree-")
+	if err != nil {
+		return "", fmt.Errorf("create temp directory: %w", err)
+	}
+	return worktreePath, nil
+}
+
+
+func CheckBranchExists(branchName string) (bool, error) {
+	cmd := exec.Command("git", "show-ref", "--verify", "--quiet", "refs/heads/"+branchName)
+	err := cmd.Run()
+	if err != nil {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) && exitError.ExitCode() == 1 {
+			return false, nil
+		}
+		return false, fmt.Errorf("check branch exists: %w", err)
+	}
+	return true, nil
+}
+
+func IsWorktreeClean(worktreePath string) (bool, error) {
+	cmd := exec.Command("git", "status", "--porcelain")
+	cmd.Dir = worktreePath
+	output, err := cmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("check worktree status: %w", err)
+	}
+	return len(strings.TrimSpace(string(output))) == 0, nil
+}

--- a/test_dry_run.sh
+++ b/test_dry_run.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-cd /Users/viacheslavezhkin/projects/gh-cp-2
-exec /Users/viacheslavezhkin/projects/gh-cp/gh-cp 1 initial --dry-run

--- a/test_dry_run_clean.sh
+++ b/test_dry_run_clean.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-cd /Users/viacheslavezhkin/projects/gh-cp-2
-git checkout initial
-git branch -D cherry-pick/add-readme-documentation 2>/dev/null || true
-exec /Users/viacheslavezhkin/projects/gh-cp/gh-cp 1 initial --dry-run

--- a/test_real.sh
+++ b/test_real.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-cd /Users/viacheslavezhkin/projects/gh-cp-2
-exec /Users/viacheslavezhkin/projects/gh-cp/gh-cp 1 initial

--- a/test_real_fixed.sh
+++ b/test_real_fixed.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-cd /Users/viacheslavezhkin/projects/gh-cp-2
-exec /Users/viacheslavezhkin/projects/gh-cp/gh-cp 1 initial


### PR DESCRIPTION
This PR implements git worktree-based cherry-picking to resolve conflicts with uncommitted changes in the working directory.

Changes:
- Add git worktree support for isolated operations
- Fix branch naming with proper suffix handling to prevent filesystem conflicts
- Replace PID-based temp directories with secure os.MkdirTemp()
- Fix PR creation with --head flag specification
- Add comprehensive Testing section to CLAUDE.md
- Remove misleading re-run references from conflict resolution
- Ensure consistent stdout output ordering
- Add unconditional branch cleanup

Fixes #12