### PR TITLE
Fix git worktree creation to use unique branch names (#28)

### DIFF
--- a/internal/cherry/picker.go
+++ b/internal/cherry/picker.go
@@ -57,9 +57,6 @@ func CherryPickPR(prNumber int, targetBranch string, config *github.Config) erro
 		}
 	}()
 
-	if err := git.CreateAndCheckoutBranchInDir(branchName, worktreePath); err != nil {
-		return fmt.Errorf("create branch in worktree: %w", err)
-	}
 	fmt.Printf("✓ Created and checked out branch: %s\n", branchName)
 
 	if err := git.CherryPickCommitsInDir(commitSHAs, worktreePath); err != nil {

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -14,7 +14,7 @@ func CreateWorktree(branchName, targetBranch string) (string, error) {
 		return "", err
 	}
 
-	cmdArgs := []string{"git", "worktree", "add", worktreePath, targetBranch}
+	cmdArgs := []string{"git", "worktree", "add", worktreePath, targetBranch, "-b", branchName}
 	fmt.Printf("Executing: %s\n", strings.Join(cmdArgs, " "))
 
 	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)


### PR DESCRIPTION
## Summary
- Fix git worktree add command to use proper syntax with -b flag to create unique branch names
- Remove redundant CreateAndCheckoutBranchInDir call since worktree now handles branch creation
- Prevents conflicts when target branches are already used by other worktrees

Resolves #28