### PR TITLE
Add version subcommand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,3 +123,4 @@ ls /tmp | grep gh-cp-worktree
 ## Go Style Guide
 - When adding context to returned errors, keep the context succinct by avoiding phrases like "failed to", which state the obvious and pile up as the error percolates up through the stack
 - Do not add obvious comments in the code
+- Export as less as possible

--- a/cmd/gh-cp/main.go
+++ b/cmd/gh-cp/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/theyoprst/gh-cp/internal/cherry"
 	"github.com/theyoprst/gh-cp/internal/github"
+	"github.com/theyoprst/gh-cp/internal/version"
 )
 
 var (
@@ -50,8 +51,17 @@ Target branch can be specified as 'branch' or 'remote/branch' format.`,
 	},
 }
 
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show version information",
+	Run: func(cmd *cobra.Command, args []string) {
+		version.PrintVersion()
+	},
+}
+
 func main() {
 	rootCmd.Flags().BoolVar(&dryRun, "dry-run", false, "show what would be done without executing remote operations")
+	rootCmd.AddCommand(versionCmd)
 	rootCmd.InitDefaultCompletionCmd()
 
 	if err := rootCmd.Execute(); err != nil {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,74 @@
+package version
+
+import (
+	"fmt"
+	"runtime/debug"
+	"strings"
+	"time"
+)
+
+const version = "0.1"
+
+type versionInfo struct {
+	Version       string
+	GitCommit     string
+	CommitTime    string
+	ModuleVersion string
+	ModulePath    string
+	GoVersion     string
+}
+
+func getVersionInfo() versionInfo {
+	info := versionInfo{
+		Version: version,
+	}
+
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return info
+	}
+
+	info.GoVersion = buildInfo.GoVersion
+	info.ModulePath = buildInfo.Main.Path
+	if buildInfo.Main.Version != "" && buildInfo.Main.Version != "(devel)" {
+		info.ModuleVersion = buildInfo.Main.Version
+	}
+
+	for _, setting := range buildInfo.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			info.GitCommit = setting.Value
+		case "vcs.time":
+			info.CommitTime = setting.Value
+		}
+	}
+
+	return info
+}
+
+func PrintVersion() {
+	info := getVersionInfo()
+
+	fmt.Printf("gh-cp v%s\n", info.Version)
+
+	if info.GitCommit != "" && info.CommitTime != "" {
+		commitHashShort := info.GitCommit
+		if len(info.GitCommit) >= 7 {
+			commitHashShort = info.GitCommit[:7]
+		}
+
+		commitTime := info.CommitTime
+		if t, err := time.Parse(time.RFC3339, info.CommitTime); err == nil {
+			commitTime = t.Format("2006-01-02T15:04:05Z")
+		}
+		fmt.Printf("commit %s %s\n", commitHashShort, commitTime)
+	}
+
+	if info.ModuleVersion != "" && info.ModulePath != "" {
+		fmt.Printf("module %s %s\n", info.ModulePath, info.ModuleVersion)
+	}
+
+	if info.GoVersion != "" {
+		fmt.Printf("built with go %s\n", strings.TrimPrefix(info.GoVersion, "go"))
+	}
+}


### PR DESCRIPTION
Resolves #36

Add a version subcommand that displays:
- Application version (v0.1)
- Commit hash and timestamp
- Module information with full path
- Go version used for build

Uses runtime/debug.ReadBuildInfo() for consistent behavior across all build methods (make build and go install).