### PR TITLE
Add --skip-merged-check flag to allow cherry-picking unmerged PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ gh-cp <pull-request-number> <target-branch> [--dry-run]
 - `pull-request-number` - The number of the merged pull request to cherry-pick
 - `target-branch` - The destination branch to cherry-pick the changes to (can be `branch` or `remote/branch` format)
 - `--dry-run` - (Optional) Preview mode: shows what would be done without making any remote changes
+- `--skip-merged-check` - (Optional) Skip check that PR is merged (use with caution when cherry-picking unmerged PRs)
 
 **Examples:**
 ```bash
@@ -90,6 +91,9 @@ gh-cp 1319 origin/release/v2.1
 
 # Preview the cherry-pick operation without making changes
 gh-cp 1319 release/v2.1 --dry-run
+
+# Cherry-pick an unmerged PR (use with caution)
+gh-cp 1319 release/v2.1 --skip-merged-check
 ```
 
 ## How It Works
@@ -116,7 +120,7 @@ gh-cp 1319 release/v2.1 --dry-run
 ## Current Limitations
 
 - **Conflict Resolution**: The tool does not automatically resolve merge conflicts. If conflicts occur during cherry-picking, the tool will leave the worktree in place and provide instructions for manual resolution
-- **Merged PRs Only**: Only works with merged pull requests
+- **Merged PRs Only**: By default, only works with merged pull requests (use `--skip-merged-check` to override)
 
 ## Conflict Resolution
 

--- a/cmd/gh-cp/main.go
+++ b/cmd/gh-cp/main.go
@@ -13,7 +13,8 @@ import (
 )
 
 var (
-	dryRun bool
+	dryRun          bool
+	skipMergedCheck bool
 )
 
 var rootCmd = &cobra.Command{
@@ -44,7 +45,8 @@ Target branch can be specified as 'branch' or 'remote/branch' format.`,
 		}
 
 		config := &github.Config{
-			DryRun: dryRun,
+			DryRun:          dryRun,
+			SkipMergedCheck: skipMergedCheck,
 		}
 
 		return cherry.CherryPickPR(prNumber, targetBranch, config)
@@ -61,6 +63,7 @@ var versionCmd = &cobra.Command{
 
 func main() {
 	rootCmd.Flags().BoolVar(&dryRun, "dry-run", false, "show what would be done without executing remote operations")
+	rootCmd.Flags().BoolVar(&skipMergedCheck, "skip-merged-check", false, "skip check that PR is merged (use with caution)")
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.InitDefaultCompletionCmd()
 

--- a/internal/cherry/picker.go
+++ b/internal/cherry/picker.go
@@ -22,10 +22,14 @@ func CherryPickPR(prNumber int, userTargetBranch string, config *github.Config) 
 
 	fmt.Printf("✓ Fetched PR #%d: \"%s\"\n", prData.Number, prData.Title)
 
-	if err := github.ValidatePRMerged(prData); err != nil {
-		return err
+	if config.SkipMergedCheck {
+		fmt.Printf("⚠️  Skipping merged state check (--skip-merged-check flag is set)\n")
+	} else {
+		if err := github.ValidatePRMerged(prData); err != nil {
+			return err
+		}
+		fmt.Printf("✓ Validated PR is merged\n")
 	}
-	fmt.Printf("✓ Validated PR is merged\n")
 
 	commitSHAs := github.GetCommitSHAs(prData)
 	if len(commitSHAs) == 0 {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -26,7 +26,7 @@ func FetchPRData(prNumber int) (*PRData, error) {
 
 func ValidatePRMerged(prData *PRData) error {
 	if strings.ToLower(prData.State) != "merged" {
-		return fmt.Errorf("PR #%d is not merged (state: %s)", prData.Number, prData.State)
+		return fmt.Errorf("PR #%d is not merged (state: %s). Use --skip-merged-check to override", prData.Number, prData.State)
 	}
 
 	if prData.MergeCommit == nil {

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -31,5 +31,6 @@ type Label struct {
 }
 
 type Config struct {
-	DryRun bool
+	DryRun          bool
+	SkipMergedCheck bool
 }


### PR DESCRIPTION
## Summary
Implements a --skip-merged-check flag that allows cherry-picking PRs that are not yet merged, with appropriate warnings.

## Changes
- Added --skip-merged-check flag to CLI arguments
- Shows warning when skipping the merged state check
- Enhanced error message to hint about the flag when PR is not merged

## Testing
Tested with both merged and unmerged PRs in dry-run mode to verify the flag works correctly.

Fixes #40